### PR TITLE
Herokurize

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: flashpaper 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: flashpaper 
+web: go-flashpaper 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ It is a web service that allows you to upload text snippets or files and generat
 6. Run go-flashpaper: `./go-flashpaper`
 7. Connect to the web service via `https://yourserver.example.com:8443` (note: 8443 is the default port, so no one has an excuse to run this as root)
 8. Share secret things.
+
+## Deploy to Heroku
+
+go-flashpaper works on Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/staaldraad/go-flashpaper)
  
 ## FAQ
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "go-flashpaper on Heroku",
+  "description": "Runs rawdigits/go-flashpaper on Heroku",
+  "repository": "https://github.com/staaldraad/go-flashpaper",
+  "keywords": ["flashpaper", "pew"]
+}

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+    "os"
 	"strings"
 	"sync"
 	"time"
@@ -211,7 +212,13 @@ func main() {
 	//You can uncomment the non TLS version of ListenAndServe and
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
-	err := http.ListenAndServeTLS(":8443", "server.crt", "server.key", nil)
+    PORT := os.Getenv("PORT")
+    if PORT == "" {
+        PORT = "8443"
+    }
+
+    //err := http.ListenAndServeTLS(fmt.Sprintf(":%d",PORT), "server.crt", "server.key", nil)
+	err := http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
 	if err != nil {
 		fmt.Printf("main(): %s\n", err)
 		fmt.Printf("Errors usually mean you don't have the required server.crt or server.key files.\n")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,6 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [],
+	"rootPath": "github.com/staaldraad/go-flashpaper"
+}


### PR DESCRIPTION
Makes go-flashpaper deployable on Heroku.

**Note** this does mean that it no longer listens on TLS by default. Since Heroku automatically supplies us with TLS. 

_Todo:_ Default to TLS when not run on Heroku. Maybe detect if the PORT environmental variable is set or if server.crt and server.key aren't accessible. 