### PR TITLE
Default to TLS, unless on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,5 +2,11 @@
   "name": "go-flashpaper on Heroku",
   "description": "Runs rawdigits/go-flashpaper on Heroku",
   "repository": "https://github.com/staaldraad/go-flashpaper",
-  "keywords": ["flashpaper", "pew"]
+  "keywords": ["flashpaper", "pew"],
+  "env": {
+      "HEROKU":{
+        "description": "If we are running on Heroku",
+        "value": "TRUE"
+      }
+  }
 }

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -213,16 +213,14 @@ func main() {
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
     PORT := os.Getenv("PORT")
-    heroku := true
 
     if PORT == "" {
         PORT = "8443"
-        heroku = false
     }
 
     var err error
 
-    if heroku {
+    if os.Getenv("HEROKU") == "TRUE" {
 	    err = http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
     } else {
         err = http.ListenAndServeTLS(fmt.Sprintf(":%s",PORT), "server.crt", "server.key", nil)

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -213,12 +213,21 @@ func main() {
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
     PORT := os.Getenv("PORT")
+    heroku := true
+
     if PORT == "" {
         PORT = "8443"
+        heroku = false
     }
 
-    //err := http.ListenAndServeTLS(fmt.Sprintf(":%d",PORT), "server.crt", "server.key", nil)
-	err := http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
+    var err error
+
+    if heroku {
+	    err = http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
+    } else {
+        err = http.ListenAndServeTLS(fmt.Sprintf(":%s",PORT), "server.crt", "server.key", nil)
+    }
+
 	if err != nil {
 		fmt.Printf("main(): %s\n", err)
 		fmt.Printf("Errors usually mean you don't have the required server.crt or server.key files.\n")


### PR DESCRIPTION
Sets an ENV variable to indicate we are on Heroku, and thus disable TLS. This ensures that TLS is still the default when we aren't on Heroku